### PR TITLE
docs: fix incorrect file reference and conda env name

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ GSB user study on long- and short-video generation. The numbers denote the perce
 |   +-- src/ltx_distillation/         # DMD wrappers, AV pipelines, memory bank, utils
 |   `-- scripts/multishot_inference_dmd.py
 +-- inference.py                      # main entrypoint (load once, infer all)
-+-- scripts/merge_checkpoint.py       # dev tool: merge base + DMD into release ckpt
 +-- requirements.txt
 `-- environment.yml
 ```

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@
 #
 # Create with:
 #     conda env create -f environment.yml
-#     conda activate ltx-2
+#     conda activate echo-long
 #
 # This installs Python 3.11 plus ffmpeg from conda-forge, then pulls the
 # Python deps (torch family with CUDA 12.8) from pip via requirements.txt.


### PR DESCRIPTION
- Remove non-existent scripts/merge_checkpoint.py from README layout\n- Fix environment.yml comment: ltx-2 -> echo-long