### PR TITLE
docs: header link wrap + LTX-2.5 / accel roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Echo-WM is on **LTX-2.3** today. **LTX-2.5** Base / Causal and the accel stack a
 - [ ] Echo-WM Causal (LTX-2.5)
 
 **Accel**
-- [ ] Few-step distillation
 - [ ] FlashAttention / FlashInfer
 - [ ] Paged KV-cache
 - [ ] FP8 / TensorRT

--- a/README.md
+++ b/README.md
@@ -64,30 +64,19 @@ exact files and paths.
 
 ## Roadmap
 
-The current release is built on **LTX-2.3**. Next we are bringing up **LTX-2.5**
-as the backbone, then the serving stack around it.
+Current release is **LTX-2.3**. **LTX-2.5** and the accel stack are next.
 
-| | Item | Status | Notes |
-|---|---|---|---|
-| **Backbone** | LTX-2.3 Base | ✅ shipped | Bidirectional audio-visual DiT used by Echo-LongVideo and Echo-WM Base |
-| | LTX-2.3 Causal / Flash | ✅ shipped | Chunk-causal attention, KV-cache rollout, 4-step student — see [`echo_wm/README_CAUSAL.md`](echo_wm/README_CAUSAL.md) |
-| | LTX-2.5 Base | 🗓️ planned | Load official LTX-2.5 weights (Gemma 4 TE, 2.5 VAE / DiT) into the existing bidirectional path |
-| | LTX-2.5 Causal | 🗓️ planned | Same causal / Flash recipe on the 2.5 backbone: block-causal masks, sink+FIFO cache, few-step distillation |
-| **Accel** | Few-step distillation | 🗓️ planned | Push 2.5 Base and Causal onto a shared consistency / DMD student |
-| | Attention kernels | 🗓️ planned | FlashAttention / FlashInfer for video, audio, and UCPE branches |
-| | KV-cache infra | 🗓️ planned | Paged / variable-length cache, RoPE + UCPE rebase on eviction |
-| | Runtime compile | 🗓️ planned | FP8 + `torch.compile` / TensorRT execution for the DiT forward |
-| | Serving | 🗓️ planned | Multi-GPU data-parallel inference and host-side prep overlap |
-
-```text
-LTX-2.3  ── Base ✅ ── Causal / Flash ✅
-                │
-                ▼
-LTX-2.5  ── Base 🗓️ ── Causal 🗓️ ── Accel infra 🗓️
-```
-
-Nothing in the planned rows is available in this repo yet. Tracking only —
-APIs and configs will land with the corresponding drop.
+| | Item | Status |
+|---|---|:---:|
+| **Backbone** | LTX-2.3 Base | ✅ |
+| | LTX-2.3 Causal / Flash | ✅ |
+| | LTX-2.5 Base | |
+| | LTX-2.5 Causal | |
+| **Accel** | Few-step distillation | |
+| | FlashAttention / FlashInfer | |
+| | Paged KV-cache | |
+| | FP8 / TensorRT | |
+| | Multi-GPU serving | |
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -66,17 +66,18 @@ exact files and paths.
 
 Echo-WM is on **LTX-2.3** today. **LTX-2.5** Base / Causal and the accel stack are next.
 
-| | Item | Status |
-|---|---|:---:|
-| **Backbone** | Echo-WM Base (LTX-2.3) | ✅ |
-| | Echo-WM Flash / Causal (LTX-2.3) | ✅ |
-| | Echo-WM Base (LTX-2.5) | |
-| | Echo-WM Causal (LTX-2.5) | |
-| **Accel** | Few-step distillation | |
-| | FlashAttention / FlashInfer | |
-| | Paged KV-cache | |
-| | FP8 / TensorRT | |
-| | Multi-GPU serving | |
+**Backbone**
+- [x] Echo-WM Base (LTX-2.3)
+- [x] Echo-WM Flash / Causal (LTX-2.3)
+- [ ] Echo-WM Base (LTX-2.5)
+- [ ] Echo-WM Causal (LTX-2.5)
+
+**Accel**
+- [ ] Few-step distillation
+- [ ] FlashAttention / FlashInfer
+- [ ] Paged KV-cache
+- [ ] FP8 / TensorRT
+- [ ] Multi-GPU serving
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -62,16 +62,16 @@ exact files and paths.
 
 **For academic research and non-commercial use only.**
 
-## Roadmap
+## Echo-WM Roadmap
 
-Current release is **LTX-2.3**. **LTX-2.5** and the accel stack are next.
+Echo-WM is on **LTX-2.3** today. **LTX-2.5** Base / Causal and the accel stack are next.
 
 | | Item | Status |
 |---|---|:---:|
-| **Backbone** | LTX-2.3 Base | ✅ |
-| | LTX-2.3 Causal / Flash | ✅ |
-| | LTX-2.5 Base | |
-| | LTX-2.5 Causal | |
+| **Backbone** | Echo-WM Base (LTX-2.3) | ✅ |
+| | Echo-WM Flash / Causal (LTX-2.3) | ✅ |
+| | Echo-WM Base (LTX-2.5) | |
+| | Echo-WM Causal (LTX-2.5) | |
 | **Accel** | Few-step distillation | |
 | | FlashAttention / FlashInfer | |
 | | Paged KV-cache | |

--- a/README.md
+++ b/README.md
@@ -64,32 +64,23 @@ exact files and paths.
 
 ## Echo-WM Roadmap
 
-On **LTX-2.3** now. Next: **LTX-2.5** Base / Causal, then the accel stack.
+Echo-WM is on **LTX-2.3** today. Next we move Base and Causal onto **LTX-2.5**,
+then cut long-rollout cost with sparse attention and a tighter cache / runtime
+stack.
 
-<table>
-<tr>
-<th align="left" width="50%">Backbone</th>
-<th align="left" width="50%">Accel</th>
-</tr>
-<tr>
-<td valign="top">
+### Backbone
 
-- [x] LTX-2.3 · Base
-- [x] LTX-2.3 · Flash / Causal
-- [ ] LTX-2.5 · Base
-- [ ] LTX-2.5 · Causal
+- [x] **LTX-2.3 · Base** — bidirectional audio-visual DiT used by Echo-WM Base (~10 s).
+- [x] **LTX-2.3 · Flash / Causal** — chunk-causal attention, KV-cache rollout, 4-step Flash. See [`echo_wm/README_CAUSAL.md`](echo_wm/README_CAUSAL.md).
+- [ ] **LTX-2.5 · Base** — load official LTX-2.5 weights (Gemma 4 TE, 2.5 VAE / DiT) into the existing bidirectional path.
+- [ ] **LTX-2.5 · Causal** — the same Flash recipe on 2.5: block-causal masks, sink+FIFO cache, few-step student.
 
-</td>
-<td valign="top">
+### Accel
 
-- [ ] FlashAttention / FlashInfer
-- [ ] Paged KV-cache
-- [ ] FP8 / TensorRT
-- [ ] Multi-GPU serving
-
-</td>
-</tr>
-</table>
+- [ ] **Sparse attention** — SageAttention and similar sparse / low-bit kernels on video, audio, and UCPE branches.
+- [ ] **FlashAttention / FlashInfer** — fused attention for long causal windows without blowing up HBM.
+- [ ] **Paged KV-cache** — variable-length cache so rollouts stay bounded; rebase RoPE and UCPE when tokens evict.
+- [ ] **FP8 / TensorRT** — compile the DiT forward at lower precision for decode-time throughput.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ checkpoints, and entrypoint — pick the one you need and follow its README.
 
 ```text
 JoyAI-Echo/
-+-- echo_longvideo/   # long-video generation: inference.py, configs/, prompts/, ltx-*
-`-- echo_wm/          # world model: inference_wm.py, Gradio demo, bundled ltx-*
+├── echo_longvideo/   # long-video generation: inference.py, configs/, prompts/, ltx-*
+└── echo_wm/          # world model: inference_wm.py, Gradio demo, bundled ltx-*
 ```
 
 The two do not share a Python environment or a checkpoint directory. `echo_wm/`

--- a/README.md
+++ b/README.md
@@ -64,19 +64,32 @@ exact files and paths.
 
 ## Echo-WM Roadmap
 
-Echo-WM is on **LTX-2.3** today. **LTX-2.5** Base / Causal and the accel stack are next.
+On **LTX-2.3** now. Next: **LTX-2.5** Base / Causal, then the accel stack.
 
-**Backbone**
-- [x] Echo-WM Base (LTX-2.3)
-- [x] Echo-WM Flash / Causal (LTX-2.3)
-- [ ] Echo-WM Base (LTX-2.5)
-- [ ] Echo-WM Causal (LTX-2.5)
+<table>
+<tr>
+<th align="left" width="50%">Backbone</th>
+<th align="left" width="50%">Accel</th>
+</tr>
+<tr>
+<td valign="top">
 
-**Accel**
+- [x] LTX-2.3 · Base
+- [x] LTX-2.3 · Flash / Causal
+- [ ] LTX-2.5 · Base
+- [ ] LTX-2.5 · Causal
+
+</td>
+<td valign="top">
+
 - [ ] FlashAttention / FlashInfer
 - [ ] Paged KV-cache
 - [ ] FP8 / TensorRT
 - [ ] Multi-GPU serving
+
+</td>
+</tr>
+</table>
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
   <a href="https://arxiv.org/abs/2608.23383"><b>📄 Paper 1.5</b></a> |
   <a href="https://arxiv.org/abs/2608.23189"><b>📄 Echo-WM Paper</b></a> |
   <a href="https://echo-team-joy-future-academy-jd.github.io/Echo-1.5-Page/"><b>🌐 Project Page</b></a> |
-  <a href="https://huggingface.co/jdopensource/JoyAI-Echo"><b>🤗 Long Video Hugging Face</b></a> |
-  <a href="https://huggingface.co/Echo-Team/Echo-WM"><b>🤗 WM Hugging Face</b></a> |
+  <a href="https://huggingface.co/jdopensource/JoyAI-Echo"><b>🤗 Long Video Hugging Face</b></a>
+</p>
+<p>
+  <a href="https://huggingface.co/Echo-Team/Echo-WM"><b>🤗 World Model Hugging Face</b></a> |
   <a href="https://github.com/zhuang2002/ComfyUI_JoyAI_Echo"><b>🖥️ ComfyUI</b></a>
 </p>
 
@@ -59,6 +61,33 @@ Checkpoints are downloaded separately in both cases. See each README for the
 exact files and paths.
 
 **For academic research and non-commercial use only.**
+
+## Roadmap
+
+The current release is built on **LTX-2.3**. Next we are bringing up **LTX-2.5**
+as the backbone, then the serving stack around it.
+
+| | Item | Status | Notes |
+|---|---|---|---|
+| **Backbone** | LTX-2.3 Base | ✅ shipped | Bidirectional audio-visual DiT used by Echo-LongVideo and Echo-WM Base |
+| | LTX-2.3 Causal / Flash | ✅ shipped | Chunk-causal attention, KV-cache rollout, 4-step student — see [`echo_wm/README_CAUSAL.md`](echo_wm/README_CAUSAL.md) |
+| | LTX-2.5 Base | 🗓️ planned | Load official LTX-2.5 weights (Gemma 4 TE, 2.5 VAE / DiT) into the existing bidirectional path |
+| | LTX-2.5 Causal | 🗓️ planned | Same causal / Flash recipe on the 2.5 backbone: block-causal masks, sink+FIFO cache, few-step distillation |
+| **Accel** | Few-step distillation | 🗓️ planned | Push 2.5 Base and Causal onto a shared consistency / DMD student |
+| | Attention kernels | 🗓️ planned | FlashAttention / FlashInfer for video, audio, and UCPE branches |
+| | KV-cache infra | 🗓️ planned | Paged / variable-length cache, RoPE + UCPE rebase on eviction |
+| | Runtime compile | 🗓️ planned | FP8 + `torch.compile` / TensorRT execution for the DiT forward |
+| | Serving | 🗓️ planned | Multi-GPU data-parallel inference and host-side prep overlap |
+
+```text
+LTX-2.3  ── Base ✅ ── Causal / Flash ✅
+                │
+                ▼
+LTX-2.5  ── Base 🗓️ ── Causal 🗓️ ── Accel infra 🗓️
+```
+
+Nothing in the planned rows is available in this repo yet. Tracking only —
+APIs and configs will land with the corresponding drop.
 
 ## Citation
 


### PR DESCRIPTION
## Summary
- Split the header badges so the first row ends at **Long Video Hugging Face**, and rename **WM Hugging Face** to **World Model Hugging Face**.
- Add a README roadmap that marks LTX-2.3 Base / Causal as shipped, and LTX-2.5 Base, LTX-2.5 Causal, plus acceleration infrastructure (distill / FlashInfer / paged KV / FP8+compile / serving) as planned.

## Test plan
- [ ] Check GitHub README wrap on desktop: first line should stop at Long Video Hugging Face
- [ ] Confirm World Model Hugging Face and ComfyUI sit on the second row
- [ ] Skim the Roadmap table for status/label accuracy


Made with [Cursor](https://cursor.com)